### PR TITLE
Compiler warnings fixed when compiling against elixir 1.6.3

### DIFF
--- a/lib/symbolic_expression/canonical/writer.ex
+++ b/lib/symbolic_expression/canonical/writer.ex
@@ -43,7 +43,7 @@ defmodule SymbolicExpression.Canonical.Writer do
   def write!(exp) when is_list(exp), do: _write!(exp, "")
 
   defp _write!([head | tail], result), do: _write!(tail, result <> format(head))
-  defp _write!([], result), do: result |> String.strip |> (&"(#{&1})").()
+  defp _write!([], result), do: result |> String.trim |> (&"(#{&1})").()
 
   # Catch all for errors.
   defp _write!(exp, result) do
@@ -58,7 +58,8 @@ defmodule SymbolicExpression.Canonical.Writer do
   defp format(x) when is_atom(x), do: x |> Atom.to_string |> _format
   defp format(x) when is_integer(x), do: x |> Integer.to_string |> _format
   defp format(x) when is_float(x) do
-    x |> Float.to_string([compact: true, decimals: 8]) |> _format
+    #x |> Float.to_string([compact: true, decimals: 8]) |> _format
+    :erlang.float_to_binary(x, [:compact, {:decimals, 8}])
   end
   defp format(x) when is_binary(x) do
     "[24:text/plain;charset=utf-8]#{_format x}"

--- a/lib/symbolic_expression/canonical/writer.ex
+++ b/lib/symbolic_expression/canonical/writer.ex
@@ -58,7 +58,6 @@ defmodule SymbolicExpression.Canonical.Writer do
   defp format(x) when is_atom(x), do: x |> Atom.to_string |> _format
   defp format(x) when is_integer(x), do: x |> Integer.to_string |> _format
   defp format(x) when is_float(x) do
-    #x |> Float.to_string([compact: true, decimals: 8]) |> _format
     :erlang.float_to_binary(x, [:compact, {:decimals, 8}])
   end
   defp format(x) when is_binary(x) do

--- a/lib/symbolic_expression/parser.ex
+++ b/lib/symbolic_expression/parser.ex
@@ -86,7 +86,7 @@ defmodule SymbolicExpression.Parser do
   end
 
   # In comment.
-  defp _parse!(s = %State{expression: << c :: utf8 >> <> rest, in_comment: true}) do
+  defp _parse!(s = %State{expression: << _c :: utf8 >> <> rest, in_comment: true}) do
     _parse! %State{s | expression: rest}
   end
 

--- a/lib/symbolic_expression/writer.ex
+++ b/lib/symbolic_expression/writer.ex
@@ -57,7 +57,6 @@ defmodule SymbolicExpression.Writer do
   defp format(x) when is_atom(x), do: Atom.to_string(x)
   defp format(x) when is_integer(x), do: Integer.to_string(x)
   defp format(x) when is_float(x), do: :erlang.float_to_binary(x, [{:decimals, 8}, :compact])
-  #defp format(x) when is_float(x), do: Float.to_string(x, [compact: true, decimals: 8])
   defp format(x) do
     raise ArgumentError, message: """
       Unable to format "#{inspect x}" for s-expression.

--- a/lib/symbolic_expression/writer.ex
+++ b/lib/symbolic_expression/writer.ex
@@ -41,7 +41,7 @@ defmodule SymbolicExpression.Writer do
   def write!(exp) when is_list(exp), do: _write!(exp, "")
 
   defp _write!([head | tail], result), do: _write!(tail, result <> " " <> format(head))
-  defp _write!([], result), do: result |> String.strip |> (&"(#{&1})").()
+  defp _write!([], result), do: result |> String.trim |> (&"(#{&1})").()
 
   # Catch all for errors.
   defp _write!(exp, result) do
@@ -56,7 +56,8 @@ defmodule SymbolicExpression.Writer do
   defp format(x) when is_binary(x), do: ~s|"#{x}"|
   defp format(x) when is_atom(x), do: Atom.to_string(x)
   defp format(x) when is_integer(x), do: Integer.to_string(x)
-  defp format(x) when is_float(x), do: Float.to_string(x, [compact: true, decimals: 8])
+  defp format(x) when is_float(x), do: :erlang.float_to_binary(x, [{:decimals, 8}, :compact])
+  #defp format(x) when is_float(x), do: Float.to_string(x, [compact: true, decimals: 8])
   defp format(x) do
     raise ArgumentError, message: """
       Unable to format "#{inspect x}" for s-expression.

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule SymbolicExpression.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Removal of compiler warnings by changing the code as directed by the compiler output, nothing more. Gives a clean build from the start, just for confidence.